### PR TITLE
tap to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "tap": "~0.3.3",
     "base64url": "0.0.3",
     "jwa": "0.0.1"
+  },
+  "devdependencies":{
+    "tap": "~0.3.3"
   }
 }


### PR DESCRIPTION
The tap module has a very long chain of dependencies.  This causes problems with some Windows based deployments.  This change moves tap to devDependencies in package.json as it isn't needed for production deployments.
