### PR TITLE
Throw a better error when no alg in header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 verbose: test/keys
-	@node test/*.test.js	
+	@node test/*.test.js
 
 test: test/keys
-	@./node_modules/.bin/tap test/*.test.js
+	@./node_modules/.bin/tape test/*.test.js
 
 test/keys:
 	@openssl genrsa 2048 > test/rsa-private.pem

--- a/index.js
+++ b/index.js
@@ -56,9 +56,20 @@ function securedInputFromJWS(jwsSig) {
 }
 
 function algoFromJWS(jwsSig) {
+  var err;
   const header = headerFromJWS(jwsSig);
   if (typeof header != 'object') {
-    throw new Error("Invalid token: no header in signature '" + jwsSig + "'");
+    err = new Error("Invalid token: no header in signature '" + jwsSig + "'");
+    err.code = "MISSING_HEADER";
+    err.signature = jwsSig;
+    throw err;
+  }
+  if (!header.alg) {
+    err = new Error("Missing `alg` field in header for signature '"+ jwsSig +"'");
+    err.code = "MISSING_ALGORITHM";
+    err.header = header;
+    err.signature = jwsSig;
+    throw err;
   }
   return header.alg;
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "jwa": "0.0.1"
   },
   "devDependencies": {
-    "tap": "~0.3.3"
+    "tape": "~2.14.0"
   }
 }

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -1,7 +1,7 @@
+/*global process*/
+const Buffer = require('buffer').Buffer;
 const fs = require('fs');
-const base64url = require('base64url');
-const crypto = require('crypto');
-const test = require('tap').test;
+const test = require('tape');
 const jws = require('..');
 
 function readfile(path) {
@@ -200,7 +200,7 @@ test('Streaming verify: ECDSA, with invalid key', function (t) {
     signature: sigStream,
     publicKey: publicKeyStream,
   });
-  verifier.on('done', function (valid, obj) {
+  verifier.on('done', function (valid) {
     t.notOk(valid, 'should not verify');
     t.end();
   });
@@ -221,6 +221,18 @@ test('jws.decode: with a bogus header ', function (t) {
   t.end();
 });
 
+test('jws.decode: missing algo in header', function (t) {
+  const header = Buffer('{"something":"not an algo"}').toString('base64');
+  const payload = Buffer('sup').toString('base64');
+  const sig = header + '.' + payload + '.';
+  try { jws.verify(sig, 'whatever') }
+  catch (e) {
+    t.same(e.code, 'MISSING_ALGORITHM');
+  }
+  t.end();
+});
+
+
 test('jws.isValid', function (t) {
   const valid = jws.sign({ header: { alg: 'hs256' }, payload: 'hi', secret: 'shhh' });
   const invalid = (function(){
@@ -233,4 +245,3 @@ test('jws.isValid', function (t) {
   t.same(jws.isValid(valid), true);
   t.end();
 });
-


### PR DESCRIPTION
[fixes #8]

This puts a check into `algoFromJWS` to make sure the `header.alg`
property exists before trying to return it. If it does not exist, we
explode early and with a descriptive error instead of exploding on a
`null` later on (damn you, null!)
