### PR TITLE
sign, verify: fixup falsy value checks

### DIFF
--- a/lib/data-stream.js
+++ b/lib/data-stream.js
@@ -9,7 +9,7 @@ function DataStream(data) {
   this.readable = true;
 
   // No input
-  if (!data) {
+  if (data === undefined || data === null) {
     this.buffer = new Buffer(0);
     return this;
   }
@@ -23,7 +23,7 @@ function DataStream(data) {
 
   // Buffer or String
   // or Object (assumedly a passworded key)
-  if (data.length || typeof data === 'object') {
+  if (data.length !== undefined || typeof data === 'object') {
     this.buffer = data;
     this.writable = false;
     process.nextTick(function () {

--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -16,7 +16,9 @@ function jwsSecuredInput(header, payload, encoding) {
 function jwsSign(opts) {
   var header = opts.header;
   var payload = opts.payload;
-  var secretOrKey = opts.secret || opts.privateKey;
+  var secretOrKey = opts.secret !== undefined
+    ? opts.secret
+    : opts.privateKey;
   var encoding = opts.encoding;
   var algo = jwa(header.alg);
   var securedInput = jwsSecuredInput(header, payload, encoding);
@@ -25,7 +27,11 @@ function jwsSign(opts) {
 }
 
 function SignStream(opts) {
-  var secret = opts.secret||opts.privateKey||opts.key;
+  var secret = opts.secret !== undefined
+    ? opts.secret
+    : opts.privateKey !== undefined
+      ? opts.privateKey
+    : opts.key;
   var secretStream = new DataStream(secret);
   this.readable = true;
   this.header = opts.header;

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -79,7 +79,11 @@ function jwsDecode(jwsSig, opts) {
 
 function VerifyStream(opts) {
   opts = opts || {};
-  var secretOrKey = opts.secret||opts.publicKey||opts.key;
+  var secretOrKey = opts.secret !== undefined
+    ? opts.secret
+    : opts.publicKey !== undefined
+      ? opts.publicKey
+    : opts.key;
   var secretStream = new DataStream(secretOrKey);
   this.readable = true;
   this.algorithm = opts.algorithm;

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -69,6 +69,24 @@ BITS.forEach(function (bits) {
   });
 });
 
+BITS.forEach(function(bits) {
+  ['', Buffer('')].forEach(function(secret) {
+    test('HMAC using SHA'+bits+' and an empty secret', function(t) {
+      const alg = 'HS'+bits;
+      const sig = jws.sign({
+        header: {
+          alg: alg
+        },
+        payload: 'data',
+        secret: secret
+      });
+      const ok = jws.verify(sig, alg, secret);
+      t.ok(ok);
+      t.end();
+    });
+  });
+});
+
 BITS.forEach(function (bits) {
   test('RSASSA using SHA-'+bits+' hash algorithm', function (t) {
     const alg = 'RS'+bits;
@@ -142,6 +160,34 @@ test('Streaming sign: HMAC', function (t) {
   sig.on('done', function (signature) {
     t.ok(jws.verify(signature, 'HS256', secret), 'should verify');
     t.end();
+  });
+});
+
+BITS.forEach(function(bits) {
+  ['', Buffer('')].forEach(function(secret) {
+    test('Streaming HMAC using SHA'+bits+' and an empty secret', function(t) {
+			const alg = 'HS'+bits;
+      const sig = jws.createSign({
+        header: {
+          alg: alg
+        },
+        secret: secret,
+        payload: 'data'
+      });
+      const verify = jws.createVerify({
+        algorithm: alg,
+        secret: secret,
+        signature: sig
+      });
+
+      verify.on('done', function(ok) {
+        t.ok(ok);
+        t.end();
+      });
+
+      sig.on('error', t.fail);
+      verify.on('error', t.fail);
+    });
   });
 });
 


### PR DESCRIPTION
in some cases, relying on falsiness when checking inputs ended up
unexpectedly ignoring things such as empty strings

Fixes: https://github.com/brianloveswords/node-jws/issues/51
