### PR TITLE
feat: npm run lint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "lint": "jshint .",
     "test": "make test"
   },
   "repository": {
@@ -28,6 +29,7 @@
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
+    "jshint": "^2.12.0",
     "semver": "^5.1.0",
     "tape": "~2.14.0"
   }

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -235,7 +235,7 @@ test('Streaming verify: errors during verify should emit as "error"', function (
     t.end();
   });
   verifierShouldError.on('error', function () {
-    t.end()
+    t.end();
   });
 });
 
@@ -297,7 +297,7 @@ test('jws.decode: with invalid json in body', function (t) {
   const sig = header + '.' + payload + '.';
   t.throws(function () {
     jws.decode(sig);
-  })
+  });
   t.end();
 });
 


### PR DESCRIPTION
### Description
This PR 
- adds jshint as a dev dependency and `npm run lint` 
- satisfies the lint rules by adding semicolons

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
