### PR TITLE
Asynchronous signing / verifying

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,46 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Linting check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Code linting
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: npm install
+      - run: npm run lint
+
+  tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [0.12, 4.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
   - 0.12
   - 4
   - 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,26 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [3.0.0]
+## [unreleased]
+### Changed
+- **BREAKING**: `jws.verify` and `jws.sign` now return a `Promise`.
+
+### Added
+- `jws.verify` and `jws.sign` now accepts a `jwa` callback which can be used to resolve an object
+  with `sign` and `verify` functions for the key/secret provided; these functions may return a
+  `Promise`.
+
+### Removed
+- Support for Node v0.10 has been removed due to lack of Promise support.
+
+## [4.0.0] - 2019-12-17
+### Changed
+- **BREAKING**: `jwa` was updated and now matches algorithm names
+  case-sensitively. Should a jws header have an alg such as "es256"
+  instead of the IANA registered "ES256" it will now throw.
+
+
+## [3.0.0] - 2015-04-08
 ### Changed
 - **BREAKING**: `jwt.verify` now requires an `algorithm` parameter, and
   `jws.createVerify` requires an `algorithm` option. The `"alg"` field
@@ -14,7 +33,7 @@ All notable changes to this project will be documented in this file.
 ## [2.0.0] - 2015-01-30
 ### Changed
 - **BREAKING**: Default payload encoding changed from `binary` to
-  `utf8`. `utf8` is a is a more sensible default than `binary` because
+  `utf8`. `utf8` is a more sensible default than `binary` because
   many payloads, as far as I can tell, will contain user-facing
   strings that could be in any language. (<code>[6b6de48]</code>)
 
@@ -25,7 +44,9 @@ All notable changes to this project will be documented in this file.
   that might be depending on a `binary` encoding of the messages, this
   is for them. (<code>[6b6de48]</code>)
 
-[unreleased]: https://github.com/brianloveswords/node-jws/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/brianloveswords/node-jws/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/brianloveswords/node-jws/compare/v3.2.2...v4.0.0
+[3.0.0]: https://github.com/brianloveswords/node-jws/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/brianloveswords/node-jws/compare/v1.0.1...v2.0.0
 
 [7880050]: https://github.com/brianloveswords/node-jws/commit/7880050

--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -27,15 +27,26 @@ function jwsSign(opts) {
   var payload = opts.payload;
   var secretOrKey = opts.secret || opts.privateKey;
   var encoding = opts.encoding;
-  var algo = jwa(header.alg);
+  var algo = opts.jwa ? opts.jwa(header.alg) : jwa(header.alg);
+  // if the supplied jwa callback did not return a value, attempt to fall back to jwa
+  if ((!algo || !algo.sign) && opts.jwa) {
+    algo = jwa(header.alg);
+  }
   var securedInput = jwsSecuredInput(header, payload, encoding);
-  var signature = algo.sign(securedInput, secretOrKey);
-  return util.format('%s.%s', securedInput, signature);
+  try {
+    return Promise.resolve(algo.sign(securedInput, secretOrKey))
+        .then(function (signature) {
+          return util.format('%s.%s', securedInput, signature);
+        });
+  } catch (e) {
+    return Promise.reject(e);
+  }
 }
 
 function SignStream(opts) {
   var secret = opts.secret||opts.privateKey||opts.key;
   var secretStream = new DataStream(secret);
+  this.jwa = opts.jwa || jwa;
   this.readable = true;
   this.header = opts.header;
   this.encoding = opts.encoding;
@@ -55,17 +66,24 @@ util.inherits(SignStream, Stream);
 
 SignStream.prototype.sign = function sign() {
   try {
-    var signature = jwsSign({
+    var self = this;
+    return jwsSign({
       header: this.header,
       payload: this.payload.buffer,
       secret: this.secret.buffer,
-      encoding: this.encoding
+      encoding: this.encoding,
+      jwa: this.jwa
+    }).then(function (signature) {
+      self.emit('done', signature);
+      self.emit('data', signature);
+      self.emit('end');
+      self.readable = false;
+      return signature;
+    }).catch(function (e) {
+      self.readable = false;
+      self.emit('error', e);
+      self.emit('close');
     });
-    this.emit('done', signature);
-    this.emit('data', signature);
-    this.emit('end');
-    this.readable = false;
-    return signature;
   } catch (e) {
     this.readable = false;
     this.emit('error', e);

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -41,17 +41,26 @@ function isValidJws(string) {
   return JWS_REGEX.test(string) && !!headerFromJWS(string);
 }
 
-function jwsVerify(jwsSig, algorithm, secretOrKey) {
+function jwsVerify(jwsSig, algorithm, secretOrKey, opts) {
+  opts = opts || {};
   if (!algorithm) {
     var err = new Error("Missing algorithm parameter for jws.verify");
     err.code = "MISSING_ALGORITHM";
-    throw err;
+    return Promise.reject(err);
   }
   jwsSig = toString(jwsSig);
   var signature = signatureFromJWS(jwsSig);
   var securedInput = securedInputFromJWS(jwsSig);
-  var algo = jwa(algorithm);
-  return algo.verify(securedInput, signature, secretOrKey);
+  var algo = opts.jwa ? opts.jwa(algorithm) : jwa(algorithm);
+  // if the supplied jwa callback did not return a value, attempt to fall back to jwa
+  if ((!algo || !algo.verify) && opts.jwa) {
+    algo = jwa(algorithm);
+  }
+  try {
+    return Promise.resolve(algo.verify(securedInput, signature, secretOrKey));
+  } catch (e) {
+    return Promise.reject(e);
+  }
 }
 
 function jwsDecode(jwsSig, opts) {
@@ -81,6 +90,7 @@ function VerifyStream(opts) {
   opts = opts || {};
   var secretOrKey = opts.secret||opts.publicKey||opts.key;
   var secretStream = new DataStream(secretOrKey);
+  this.jwa = opts.jwa || jwa;
   this.readable = true;
   this.algorithm = opts.algorithm;
   this.encoding = opts.encoding;
@@ -98,16 +108,21 @@ function VerifyStream(opts) {
 }
 util.inherits(VerifyStream, Stream);
 VerifyStream.prototype.verify = function verify() {
+  this.readable = false;
   try {
-    var valid = jwsVerify(this.signature.buffer, this.algorithm, this.key.buffer);
-    var obj = jwsDecode(this.signature.buffer, this.encoding);
-    this.emit('done', valid, obj);
-    this.emit('data', valid);
-    this.emit('end');
-    this.readable = false;
-    return valid;
+    var self = this;
+    return jwsVerify(this.signature.buffer, this.algorithm, this.key.buffer, { jwa: this.jwa })
+      .then(function (valid) {
+        var obj = jwsDecode(self.signature.buffer, self.encoding);
+        self.emit('done', valid, obj);
+        self.emit('data', valid);
+        self.emit('end');
+        return valid;
+      }).catch(function (e) {
+        self.emit('error', e);
+        self.emit('close');
+      });
   } catch (e) {
-    this.readable = false;
     this.emit('error', e);
     this.emit('close');
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "lint": "jshint lib/ test/ index.js",
     "test": "make test"
   },
   "repository": {
@@ -28,6 +29,7 @@
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
+    "jshint": "^2.13.5",
     "semver": "^5.1.0",
     "tape": "~2.14.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# node-jws [![Build Status](https://secure.travis-ci.org/brianloveswords/node-jws.svg)](http://travis-ci.org/brianloveswords/node-jws)
+# node-jws [![Build Status](https://github.com/auth0/node-jws/actions/workflows/nodejs.yml/badge.svg)](https://github.com/auth0/node-jws/actions/workflows/nodejs.yml)
 
 An implementation of [JSON Web Signatures](http://self-issued.info/docs/draft-ietf-jose-json-web-signature.html).
 

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -54,18 +54,25 @@ BITS.forEach(function (bits) {
     const alg = 'HS'+bits;
     const header = { alg: alg, typ: 'JWT' };
     const secret = 'sup';
-    const jwsObj = jws.sign({
+    jws.sign({
       header: header,
       payload: payload,
       secret: secret,
       encoding: 'utf8',
+    }).then(function (jwsObj) {
+      return jws.verify(jwsObj, alg, secret).then(function (res) {
+        t.ok(res, 'should verify');
+        return jws.verify(jwsObj, alg, 'something else');
+      }).then(function (res) {
+        const parts = jws.decode(jwsObj);
+        t.notOk(res, 'should not verify with non-matching secret');
+        t.same(parts.payload, payload, 'should match payload');
+        t.same(parts.header, header, 'should match header');
+        t.end();
+      }).catch(function (e) {
+        t.end(e);
+      });
     });
-    const parts = jws.decode(jwsObj);
-    t.ok(jws.verify(jwsObj, alg, secret), 'should verify');
-    t.notOk(jws.verify(jwsObj, alg, 'something else'), 'should not verify with non-matching secret');
-    t.same(parts.payload, payload, 'should match payload');
-    t.same(parts.header, header, 'should match header');
-    t.end();
   });
 });
 
@@ -76,18 +83,28 @@ BITS.forEach(function (bits) {
     const privateKey = rsaPrivateKey;
     const publicKey = rsaPublicKey;
     const wrongPublicKey = rsaWrongPublicKey;
-    const jwsObj = jws.sign({
+    jws.sign({
       header: header,
       payload: payload,
       privateKey: privateKey
+    }).then(function (jwsObj) {
+      return jws.verify(jwsObj, alg, publicKey).then(function (res) {
+        t.ok(res, 'should verify');
+        return jws.verify(jwsObj, alg, wrongPublicKey);
+      }).then(function (res) {
+        t.notOk(res, 'should not verify with non-matching public key');
+        return jws.verify(jwsObj, 'HS' + bits, publicKey);
+      }).then(function (res) {
+        t.notOk(res, 'should not verify with non-matching algorithm');
+      }).then(function () {
+        const parts = jws.decode(jwsObj, { json: true });
+        t.same(parts.payload, payload, 'should match payload');
+        t.same(parts.header, header, 'should match header');
+        t.end();
+      });
+    }).catch(function (e) {
+      t.end(e);
     });
-    const parts = jws.decode(jwsObj, { json: true });
-    t.ok(jws.verify(jwsObj, alg, publicKey), 'should verify');
-    t.notOk(jws.verify(jwsObj, alg, wrongPublicKey), 'should not verify with non-matching public key');
-    t.notOk(jws.verify(jwsObj, 'HS'+bits, publicKey), 'should not verify with non-matching algorithm');
-    t.same(parts.payload, payload, 'should match payload');
-    t.same(parts.header, header, 'should match header');
-    t.end();
   });
 });
 
@@ -99,18 +116,27 @@ BITS.forEach(function (bits) {
     const privateKey = ecdsaPrivateKey[bits];
     const publicKey = ecdsaPublicKey[bits];
     const wrongPublicKey = ecdsaWrongPublicKey[bits];
-    const jwsObj = jws.sign({
+    jws.sign({
       header: header,
       payload: payloadString,
       privateKey: privateKey
+    }).then(function (jwsObj) {
+      return jws.verify(jwsObj, alg, publicKey).then(function (res) {
+        t.ok(res, 'should verify');
+        return jws.verify(jwsObj, alg, wrongPublicKey);
+      }).then(function (res) {
+        t.notOk(res, 'should not verify with non-matching public key');
+        return jws.verify(jwsObj, 'HS' + bits, publicKey);
+      }).then(function (res) {
+        const parts = jws.decode(jwsObj);
+        t.notOk(res, 'should not verify with non-matching algorithm');
+        t.same(parts.payload, payloadString, 'should match payload');
+        t.same(parts.header, header, 'should match header');
+        t.end();
+      });
+    }).catch(function (e) {
+      t.end(e);
     });
-    const parts = jws.decode(jwsObj);
-    t.ok(jws.verify(jwsObj, alg, publicKey), 'should verify');
-    t.notOk(jws.verify(jwsObj, alg, wrongPublicKey), 'should not verify with non-matching public key');
-    t.notOk(jws.verify(jwsObj, 'HS'+bits, publicKey), 'should not verify with non-matching algorithm');
-    t.same(parts.payload, payloadString, 'should match payload');
-    t.same(parts.header, header, 'should match header');
-    t.end();
   });
 });
 
@@ -118,17 +144,26 @@ test('No digital signature or MAC value included', function (t) {
   const alg = 'none';
   const header = { alg: alg };
   const payload = 'oh hey José!';
-  const jwsObj = jws.sign({
+  jws.sign({
     header: header,
     payload: payload,
+  }).then(function (jwsObj) {
+    return jws.verify(jwsObj, alg).then(function (res) {
+      t.ok(res, 'should verify');
+      return jws.verify(jwsObj, alg, 'anything');
+    }).then(function (res) {
+      t.ok(res, 'should still verify');
+      return jws.verify(jwsObj, 'HS256', 'anything');
+    }).then(function (res) {
+      const parts = jws.decode(jwsObj);
+      t.notOk(res, 'should not verify with non-matching algorithm');
+      t.same(parts.payload, payload, 'should match payload');
+      t.same(parts.header, header, 'should match header');
+      t.end();
+    });
+  }).catch(function (e) {
+    t.end(e);
   });
-  const parts = jws.decode(jwsObj);
-  t.ok(jws.verify(jwsObj, alg), 'should verify');
-  t.ok(jws.verify(jwsObj, alg, 'anything'), 'should still verify');
-  t.notOk(jws.verify(jwsObj, 'HS256', 'anything'), 'should not verify with non-matching algorithm');
-  t.same(parts.payload, payload, 'should match payload');
-  t.same(parts.header, header, 'should match header');
-  t.end();
 });
 
 test('Streaming sign: HMAC', function (t) {
@@ -140,8 +175,15 @@ test('Streaming sign: HMAC', function (t) {
   });
   dataStream.pipe(sig.payload);
   sig.on('done', function (signature) {
-    t.ok(jws.verify(signature, 'HS256', secret), 'should verify');
-    t.end();
+    jws.verify(signature, 'HS256', secret).then(function (res) {
+      t.ok(res, 'should verify');
+      t.end();
+    }).catch(function (e) {
+      t.end(e);
+    });
+  });
+  sig.on('error', function (error) {
+    t.end(error);
   });
 });
 
@@ -160,10 +202,20 @@ test('Streaming sign: RSA', function (t) {
   });
 
   sig.on('done', function (signature) {
-    t.ok(jws.verify(signature, 'RS256', publicKey), 'should verify');
-    t.notOk(jws.verify(signature, 'RS256', wrongPublicKey), 'should not verify');
-    t.same(jws.decode(signature).payload, readfile('data.txt'), 'got all the data');
-    t.end();
+    jws.verify(signature, 'RS256', publicKey).then(function (res) {
+      t.ok(res, 'should verify');
+      return jws.verify(signature, 'RS256', wrongPublicKey);
+    }).then(function (res) {
+      t.notOk(res, 'should not verify');
+      t.same(jws.decode(signature).payload, readfile('data.txt'), 'got all the data');
+      t.end();
+    }).catch(function (e) {
+      t.end(e);
+    });
+  });
+
+  sig.on('error', function (error) {
+    t.end(error);
   });
 });
 
@@ -178,10 +230,19 @@ test('Streaming sign: RSA, predefined streams', function (t) {
     privateKey: privateKeyStream
   });
   sig.on('done', function (signature) {
-    t.ok(jws.verify(signature, 'RS256', publicKey), 'should verify');
-    t.notOk(jws.verify(signature, 'RS256', wrongPublicKey), 'should not verify');
-    t.same(jws.decode(signature).payload, readfile('data.txt'), 'got all the data');
-    t.end();
+    jws.verify(signature, 'RS256', publicKey).then(function (res) {
+      t.ok(res, 'should verify');
+      return jws.verify(signature, 'RS256', wrongPublicKey);
+    }).then(function (res) {
+      t.notOk(res, 'should not verify');
+      t.same(jws.decode(signature).payload, readfile('data.txt'), 'got all the data');
+      t.end();
+    }).catch(function (e) {
+      t.end(e);
+    });
+  });
+  sig.on('error', function (error) {
+    t.end(error);
   });
 });
 
@@ -200,6 +261,9 @@ test('Streaming verify: ECDSA', function (t) {
   verifier.on('done', function (valid) {
     t.ok(valid, 'should verify');
     t.end();
+  });
+  verifier.on('error', function (error) {
+    t.end(error);
   });
 });
 
@@ -221,6 +285,9 @@ test('Streaming verify: ECDSA, with invalid key', function (t) {
     t.notOk(valid, 'should not verify');
     t.end();
   });
+  verifier.on('error', function (error) {
+    t.end(error);
+  });
 });
 
 test('Streaming verify: errors during verify should emit as "error"', function (t) {
@@ -235,23 +302,26 @@ test('Streaming verify: errors during verify should emit as "error"', function (
     t.end();
   });
   verifierShouldError.on('error', function () {
-    t.end()
+    t.end();
   });
 });
 
 if (SUPPORTS_ENCRYPTED_KEYS) {
   test('Signing: should accept an encrypted key', function (t) {
     const alg = 'RS256';
-    const signature = jws.sign({
+    jws.sign({
       header: { alg: alg },
       payload: 'verifyme',
       privateKey: {
         key: rsaPrivateKeyEncrypted,
         passphrase: encryptedPassphrase
       }
+    }).then(function (signature) {
+      t.ok(jws.verify(signature, 'RS256', rsaPublicKey));
+      t.end();
+    }).catch(function (e) {
+      t.end(e);
     });
-    t.ok(jws.verify(signature, 'RS256', rsaPublicKey));
-    t.end();
   });
 
   test('Streaming sign: should accept an encrypted key', function (t) {
@@ -272,6 +342,9 @@ if (SUPPORTS_ENCRYPTED_KEYS) {
     verifier.on('done', function (verified) {
       t.ok(verified);
       t.end();
+    });
+    verifier.on('error', function (error) {
+      t.end(error);
     });
   });
 }
@@ -297,7 +370,7 @@ test('jws.decode: with invalid json in body', function (t) {
   const sig = header + '.' + payload + '.';
   t.throws(function () {
     jws.decode(sig);
-  })
+  });
   t.end();
 });
 
@@ -305,27 +378,84 @@ test('jws.verify: missing or invalid algorithm', function (t) {
   const header = Buffer.from('{"something":"not an algo"}').toString('base64');
   const payload = Buffer.from('sup').toString('base64');
   const sig = header + '.' + payload + '.';
-  try { jws.verify(sig) }
-  catch (e) {
+  jws.verify(sig).then(function () {
+    // should have rejected before this
+    t.fail();
+  }).catch(function (e) {
     t.same(e.code, 'MISSING_ALGORITHM');
-  }
-  try { jws.verify(sig, 'whatever') }
-  catch (e) {
+  }).then(function () {
+    return jws.verify(sig, 'whatever').then(function () {
+      // should have rejected before this
+      t.fail();
+    });
+  }).catch(function (e) {
     t.ok(e.message.match('"whatever" is not a valid algorithm.'));
-  }
-  t.end();
+    t.end();
+  }).catch(function (e) {
+    t.end(e);
+  });
 });
 
 
 test('jws.isValid', function (t) {
-  const valid = jws.sign({ header: { alg: 'HS256' }, payload: 'hi', secret: 'shhh' });
-  const invalid = (function(){
-    const header = Buffer.from('oh hei José!').toString('base64');
-    const payload = Buffer.from('sup').toString('base64');
-    return header + '.' + payload + '.';
-  })();
-  t.same(jws.isValid('http://sub.domain.org'), false);
-  t.same(jws.isValid(invalid), false);
-  t.same(jws.isValid(valid), true);
-  t.end();
+  jws.sign({ header: { alg: 'HS256' }, payload: 'hi', secret: 'shhh' }).then(function (valid) {
+    const invalid = (function () {
+      const header = Buffer.from('oh hei José!').toString('base64');
+      const payload = Buffer.from('sup').toString('base64');
+      return header + '.' + payload + '.';
+    })();
+    t.same(jws.isValid('http://sub.domain.org'), false);
+    t.same(jws.isValid(invalid), false);
+    t.same(jws.isValid(valid), true);
+    t.end();
+  }).catch(function (e) {
+    t.end(e);
+  });
+});
+
+test('custom jwa', function (t) {
+  var verifyCalls = [];
+  var signCalls = [];
+  function jwa(alg) {
+    if (alg === 'CUSTOM') {
+      return {
+        verify: function (payload, signature, secret) {
+          verifyCalls.push([payload, signature, secret]);
+          if (secret === 'shhh') {
+            return signature === 'SIGNED';
+          }
+          return false;
+        },
+        sign: function (payload, secret) {
+          signCalls.push([payload, secret]);
+          if (secret === 'shhh') {
+            return 'SIGNED';
+          }
+          throw new Error('unable to sign');
+        },
+      };
+    }
+  }
+  jws.sign({ header: { alg: 'CUSTOM' }, payload: 'hi', secret: 'shhh', jwa: jwa }).then(function (signature) {
+    t.same(signCalls.length, 1);
+    t.same(signature, 'eyJhbGciOiJDVVNUT00ifQ.aGk.SIGNED');
+    return jws.sign({ header: { alg: 'CUSTOM' }, payload: 'hi', secret: 'bad', jwa: jwa }).then(function () {
+      t.fail();
+    }).catch(function (e) {
+      t.same(signCalls.length, 2);
+      t.same(e.message, 'unable to sign');
+    });
+  }).then(function () {
+    return jws.verify('eyJhbGciOiJDVVNUT00ifQ.aGk.SIGNED', 'CUSTOM', 'shhh', { jwa: jwa });
+  }).then(function (valid) {
+    t.same(verifyCalls.length, 1);
+    t.ok(valid);
+    return jws.verify('eyJhbGciOiJDVVNUT00ifQ.aGk.invalid', 'CUSTOM', 'shhh', { jwa: jwa });
+  }).then(function (valid) {
+    t.same(verifyCalls.length, 2);
+    t.notOk(valid);
+    t.end();
+  }).catch(function (e) {
+    t.end(e);
+  });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This is a major change that moves the library towards async based signing/verifying. As such, support for node v0.10 has been dropped to allow the use of first class promises.

I have updated the existing tests/documentation as well as the changelog.

This also adds support for providing custom JWA implementations (assuming they stick to the signer/verifier API). This has also been documented in the readme.

- Refactored to return Promises for verify / sign
- Removed support for Node v0.10
- Updated changelog and readme
- Added lint command (`npm run lint`)
- Added github workflow for CI instead of travis (travis integration is broken)

### References

see #103 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
