### PR TITLE
Expose and document existing 'json' option in jws.decode and jws.createVerify APIs

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -83,6 +83,7 @@ function VerifyStream(opts) {
   var secretStream = new DataStream(secretOrKey);
   this.readable = true;
   this.algorithm = opts.algorithm;
+  this.json = opts.json;
   this.encoding = opts.encoding;
   this.secret = this.publicKey = this.key = secretStream;
   this.signature = new DataStream(opts.signature);
@@ -100,7 +101,7 @@ util.inherits(VerifyStream, Stream);
 VerifyStream.prototype.verify = function verify() {
   try {
     var valid = jwsVerify(this.signature.buffer, this.algorithm, this.key.buffer);
-    var obj = jwsDecode(this.signature.buffer, this.encoding);
+    var obj = jwsDecode(this.signature.buffer, {json: this.json, encoding: this.encoding});
     this.emit('done', valid, obj);
     this.emit('data', valid);
     this.emit('end');

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,10 @@ Note that the `"alg"` value from the signature header is ignored.
 (Synchronous) Returns the decoded header, decoded payload, and signature
 parts of the JWS Signature.
 
+Options:
+
+* `json` (Optional, defaults to `false`)
+
 Returns an object with three properties, e.g.
 ```js
 { header: { alg: 'HS256' },
@@ -141,9 +145,10 @@ Options:
 * `algorithm`
 * `key` || `publicKey` || `secret`
 * `encoding` (Optional, defaults to 'utf8')
+* `json` (Optional, defaults to `false`)
 
-All options expect a string or a buffer when the value is known ahead of
-time, or a stream for convenience.
+All options (except `encoding` and `json`) expect a string or a buffer 
+when the value is known ahead of time, or a stream for convenience.
 
 Example:
 

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -301,6 +301,75 @@ test('jws.decode: with invalid json in body', function (t) {
   t.end();
 });
 
+test('jws.decode: with typ of \'JWT\' in header', function (t) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const encoding = 'utf8';
+  const jwsObj = jws.sign({
+    header: header,
+    payload: payload,
+    secret: 'sup',
+    encoding: encoding,
+  });
+  const parts = jws.decode(jwsObj);
+  t.same(parts.payload, payload, 'should match JSON-parsed payload');
+  t.end();
+});
+
+test('jws.decode: with missing typ in header', function (t) {
+  const header = { alg: 'HS256' };
+  const jwsObj = jws.sign({
+    header: header,
+    payload: payload,
+    secret: 'sup',
+    encoding: 'utf8',
+  });
+  const parts = jws.decode(jwsObj);
+  t.same(parts.payload, JSON.stringify(payload), 'should match encoded payload');
+  t.not(parts.payload, payload, 'should not match JSON-parsed payload');
+  t.end();
+});
+
+test('jws.decode: with invalid typ in header', function (t) {
+  const header = { alg: 'HS256', typ: 'not a typ' };
+  const jwsObj = jws.sign({
+    header: header,
+    payload: payload,
+    secret: 'sup',
+    encoding: 'utf8',
+  });
+  const parts = jws.decode(jwsObj);
+  t.same(parts.payload, JSON.stringify(payload), 'should match encoded payload');
+  t.not(parts.payload, payload, 'should not match JSON-parsed payload');
+  t.end();
+});
+
+test('jws.decode: with missing typ in header, and json option set', function (t) {
+  const header = { alg: 'HS256' };
+  const jwsObj = jws.sign({
+    header: header,
+    payload: payload,
+    secret: 'sup',
+    encoding: 'utf8',
+  });
+  const parts = jws.decode(jwsObj, {json: true});
+  t.same(parts.payload, payload, 'should match JSON-parsed payload');
+  t.end();
+});
+
+test('jws.decode: with missing typ in header, and json option set to null', function (t) {
+  const header = { alg: 'HS256' };
+  const jwsObj = jws.sign({
+    header: header,
+    payload: payload,
+    secret: 'sup',
+    encoding: 'utf8',
+  });
+  const parts = jws.decode(jwsObj, {json: null});
+  t.same(parts.payload, JSON.stringify(payload), 'should match encoded payload');
+  t.not(parts.payload, payload, 'should not match JSON-parsed payload');
+  t.end();
+});
+
 test('jws.verify: missing or invalid algorithm', function (t) {
   const header = Buffer.from('{"something":"not an algo"}').toString('base64');
   const payload = Buffer.from('sup').toString('base64');


### PR DESCRIPTION
### Description

The `json` option is currently accepted by the `jws.decode` API, although it is not documented in repo. From its usage, it seems it intends to enable configuring how the payload should be parsed when the `typ` is not set to 'JWT' on the JWS header.

This change:
a) documents the option as part of the API
b) adds support for the option via the `jws.createVerify` API, which will pass through the option to `jws.decode` internally.

### Testing
Added tests for when:
- the `typ` is set to 'JWT'
- the `typ` is missing
- the `typ` is invalid
- the `typ` is invalid, but `json` option is set to true, forcing parsing of payload as JSON
- handle null value for `json` option as expected

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
