### PR TITLE
Add support for encoding option to jws.decode, and fix forwarding of …

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -66,9 +66,9 @@ function jwsDecode(jwsSig, opts) {
   if (!header)
     return null;
 
-  var payload = payloadFromJWS(jwsSig);
+  var payload = payloadFromJWS(jwsSig, opts.encoding);
   if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+    payload = JSON.parse(payload);
 
   return {
     header: header,
@@ -100,7 +100,7 @@ util.inherits(VerifyStream, Stream);
 VerifyStream.prototype.verify = function verify() {
   try {
     var valid = jwsVerify(this.signature.buffer, this.algorithm, this.key.buffer);
-    var obj = jwsDecode(this.signature.buffer, this.encoding);
+    var obj = jwsDecode(this.signature.buffer, {encoding: this.encoding});
     this.emit('done', valid, obj);
     this.emit('data', valid);
     this.emit('end');

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,10 @@ Note that the `"alg"` value from the signature header is ignored.
 (Synchronous) Returns the decoded header, decoded payload, and signature
 parts of the JWS Signature.
 
+Options:
+
+* `encoding` (Optional, defaults to 'utf8')
+
 Returns an object with three properties, e.g.
 ```js
 { header: { alg: 'HS256' },

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -301,6 +301,20 @@ test('jws.decode: with invalid json in body', function (t) {
   t.end();
 });
 
+test('jws.decode supports encoding option', function (t) {
+  const payloadString = 'åäöí';
+  const encoding = 'latin1';
+  const jwsObj = jws.sign({
+    header: { alg: 'HS256' },
+    payload: payloadString, 
+    secret: 'shhh', 
+    encoding: encoding
+  });
+  const parts = jws.decode(jwsObj, {encoding: encoding});
+  t.same(parts.payload, payloadString, 'should match payload');
+  t.end();
+});
+
 test('jws.verify: missing or invalid algorithm', function (t) {
   const header = Buffer.from('{"something":"not an algo"}').toString('base64');
   const payload = Buffer.from('sup').toString('base64');
@@ -315,7 +329,6 @@ test('jws.verify: missing or invalid algorithm', function (t) {
   }
   t.end();
 });
-
 
 test('jws.isValid', function (t) {
   const valid = jws.sign({ header: { alg: 'HS256' }, payload: 'hi', secret: 'shhh' });


### PR DESCRIPTION
### Description

(trivially) Adds support for `encoding` option to `jws.decode` API by passing this encoding from `opts` to `payloadFromJWS`. Also, fixes the broken `encoding` option currently documented for the `jws.createVerify` API, by properly passing the `encoding` option to be wrapped in an object passed to implementation call to `decode`. 

This change should make this option functional for both these APIs.

### References

Largely the same code change as proposed in #86, with change to remove passing of encoding option to `JSON.parse` as this is ignored, and properly forward option from `VerifyStream.proto.verify` method (and fix conflicts and clean history).

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
