### PR TITLE
Fix: Catch errors from JSON.parse

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -68,7 +68,11 @@ function jwsDecode(jwsSig, opts) {
 
   var payload = payloadFromJWS(jwsSig);
   if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+    try {
+      payload = JSON.parse(payload, opts.encoding);
+    } catch (e) {
+      return null;
+    }
 
   return {
     header: header,


### PR DESCRIPTION
Keep the contract that the decode returns null on errors

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

```
➜ node
Welcome to Node.js v16.19.0.
Fix: Catch errors from JSON.parse
Type ".help" for more information.
> JSON.parse("xx")
Uncaught SyntaxError: Unexpected token x in JSON at position 0
>
```

### Checklist

- [ ] This change adds test coverage for new/changed/fixed functionality
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
