### PR TITLE
Cleanup: Remove unsupported opts.encoding to JSON.parse

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -68,7 +68,7 @@ function jwsDecode(jwsSig, opts) {
 
   var payload = payloadFromJWS(jwsSig);
   if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+    payload = JSON.parse(payload);
 
   return {
     header: header,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Remove unsupported opts.encoding to JSON.parse:

> **reviver** Optional
>
> If a function, this prescribes how each value originally produced by
> parsing is transformed before being returned. Non-callable values are
> ignored. 

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse

### References

- https://github.com/auth0/node-jws/pull/86#discussion_r1090150451
- https://github.com/auth0/node-jws/pull/106#issuecomment-1419418640

### Checklist

- [ ] This change adds test coverage for new/changed/fixed functionality
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
