### PR TITLE
feat: handle large number

### DIFF
--- a/lib/safe-parse.js
+++ b/lib/safe-parse.js
@@ -1,0 +1,40 @@
+function isObject(thing) {
+  return Object.prototype.toString.call(thing) === "[object Object]";
+}
+
+function safeJsonParse(thing) {
+  if (isObject(thing)) return thing;
+  try {
+    return JSON.parse(thing);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+// Custom JSON parser that preserves big integer precision
+function safeJsonParseWithBigInt(text) {
+  // Use regex to match big integers (including negative numbers) and convert them to strings
+  var processedText = text.replace(
+    /:(\s*)(-?\d{16,})/g,
+    function (match, space, number) {
+      // If the number exceeds the safe integer range, convert it to a string
+      if (
+        parseInt(number) > Number.MAX_SAFE_INTEGER ||
+        parseInt(number) < Number.MIN_SAFE_INTEGER
+      ) {
+        return ":" + space + '"' + number + '"';
+      }
+      return match;
+    }
+  );
+
+  try {
+    return JSON.parse(processedText);
+  } catch (e) {
+    // If the processed text fails to parse, try the original text
+    return JSON.parse(text);
+  }
+}
+
+exports.safeJsonParse = safeJsonParse;
+exports.safeJsonParseWithBigInt = safeJsonParseWithBigInt;

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -7,16 +7,7 @@ var toString = require('./tostring');
 var util = require('util');
 var JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/;
 
-function isObject(thing) {
-  return Object.prototype.toString.call(thing) === '[object Object]';
-}
-
-function safeJsonParse(thing) {
-  if (isObject(thing))
-    return thing;
-  try { return JSON.parse(thing); }
-  catch (e) { return undefined; }
-}
+var { safeJsonParse, safeJsonParseWithBigInt } = require("./safe-parse");
 
 function headerFromJWS(jwsSig) {
   var encodedHeader = jwsSig.split('.', 1)[0];
@@ -67,8 +58,14 @@ function jwsDecode(jwsSig, opts) {
     return null;
 
   var payload = payloadFromJWS(jwsSig);
-  if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+  if (header.typ === 'JWT' || opts.json) {
+    // Use custom parser to preserve big integer precision
+    if (opts.preserveBigInt !== false) {
+      payload = safeJsonParseWithBigInt(payload);
+    } else {
+      payload = JSON.parse(payload, opts.encoding);
+    }
+  }
 
   return {
     header: header,

--- a/test/safeJsonParseWithBigInt.test.js
+++ b/test/safeJsonParseWithBigInt.test.js
@@ -1,0 +1,151 @@
+/*global process*/
+const test = require("tape");
+const { safeJsonParseWithBigInt } = require("../lib/safe-parse");
+
+test("safeJsonParseWithBigInt: Basic functionality test", function (t) {
+  // Use the specified payload string
+  const payloadString = '{"userId":13123213123163776887779878}';
+
+  const result = safeJsonParseWithBigInt(payloadString);
+
+  t.ok(result !== null, "Parse should succeed");
+  t.equal(
+    typeof result.userId,
+    "string",
+    "Big integer should be parsed as string"
+  );
+  t.equal(
+    result.userId,
+    "13123213123163776887779878",
+    "Big integer should maintain precision"
+  );
+
+  // Verify precision is maintained
+  const originalNumber = 13123213123163776887779878;
+  t.notEqual(
+    result.userId,
+    originalNumber,
+    "Parsed value should not equal original number (due to precision loss)"
+  );
+  t.equal(
+    result.userId,
+    "13123213123163776887779878",
+    "Parsed value should equal the string representation of original number"
+  );
+
+  t.end();
+});
+
+test("safeJsonParseWithBigInt: Boundary value test", function (t) {
+  const testCases = [
+    {
+      name: "Maximum safe integer",
+      json: '{"num":9007199254740991}',
+      expectedType: "number",
+      expectedValue: 9007199254740991,
+    },
+    {
+      name: "Exceeds safe integer range",
+      json: '{"num":9007199254740992}',
+      expectedType: "string",
+      expectedValue: "9007199254740992",
+    },
+    {
+      name: "Very large number",
+      json: '{"num":123456789012345678901234567890}',
+      expectedType: "string",
+      expectedValue: "123456789012345678901234567890",
+    },
+    {
+      name: "Minimum safe integer",
+      json: '{"num":-9007199254740991}',
+      expectedType: "number",
+      expectedValue: -9007199254740991,
+    },
+    {
+      name: "Exceeds safe integer range (negative)",
+      json: '{"num":-9007199254740992}',
+      expectedType: "string",
+      expectedValue: "-9007199254740992",
+    },
+  ];
+
+  testCases.forEach(function (testCase) {
+    const result = safeJsonParseWithBigInt(testCase.json);
+
+    t.equal(
+      typeof result.num,
+      testCase.expectedType,
+      `${testCase.name}: Number type should be correct`
+    );
+    t.same(
+      result.num,
+      testCase.expectedValue,
+      `${testCase.name}: Number value should match`
+    );
+  });
+
+  t.end();
+});
+
+test("safeJsonParseWithBigInt: Complex object test", function (t) {
+  const complexJson =
+    '{"user":{"id":13123213123163776887779878,"name":"test"},"normalNumber":12345,"bigNumber":987654321098765432109876543210}';
+
+  const result = safeJsonParseWithBigInt(complexJson);
+
+  t.ok(result !== null, "Complex object parsing should succeed");
+  t.equal(
+    typeof result.user.id,
+    "string",
+    "Big integer in nested object should be parsed as string"
+  );
+  t.equal(
+    result.user.id,
+    "13123213123163776887779878",
+    "Big integer in nested object should maintain precision"
+  );
+  t.equal(
+    typeof result.normalNumber,
+    "number",
+    "Normal number should remain as number type"
+  );
+  t.equal(
+    typeof result.bigNumber,
+    "string",
+    "Big integer should be parsed as string"
+  );
+  t.equal(
+    result.bigNumber,
+    "987654321098765432109876543210",
+    "Big integer should maintain precision"
+  );
+
+  t.end();
+});
+
+test("safeJsonParseWithBigInt: Array test", function (t) {
+  const arrayJson =
+    '[{"id":13123213123163776887779878,"name":"user1"},{"id":12345,"name":"user2"}]';
+
+  const result = safeJsonParseWithBigInt(arrayJson);
+
+  t.ok(Array.isArray(result), "Result should be an array");
+  t.equal(
+    typeof result[0].id,
+    "string",
+    "Big integer in array should be parsed as string"
+  );
+  t.equal(
+    result[0].id,
+    "13123213123163776887779878",
+    "Big integer in array should maintain precision"
+  );
+  t.equal(
+    typeof result[1].id,
+    "number",
+    "Normal number in array should remain as number type"
+  );
+
+  t.end();
+});


### PR DESCRIPTION
### Description

This PR addresses an issue in the `node-jws` library where decoding JSON Web Tokens (JWTs) containing large integers would result in a loss of precision. This issue occurs because JavaScript’s `Number` type cannot safely represent integers beyond `Number.MAX_SAFE_INTEGER`, causing the loss of accuracy.

#### Background:

The `node` service depends on tokens issued by upstream services (such as Go/Java services). Many of these tokens contain IDs stored as `long` integers. Since JavaScript cannot accurately handle such large values (e.g., larger than `Number.MAX_SAFE_INTEGER`), precision is lost when decoding these tokens. This problem leads to inaccurate processing of IDs in downstream logic.

#### Key Changes:

1. I’ve refactored the safe parsing logic into a new `safe-parse.js` file to separate concerns and improve maintainability.
2. Added a new utility function, `safeJsonParseWithBigInt`, to specifically handle large numbers by converting them into strings during the parsing process, preventing any loss of precision.
3. Created unit tests in `safeJsonParseWithBigInt.test.js` to validate the behavior of the new utility function and ensure that large numbers are correctly handled.

This change ensures that large integers are decoded accurately as strings without loss of precision, which avoids breaking the existing behavior for non-large integers.

### Reproduction Steps

To reproduce the issue and verify the fix, you can use the following payload:

```
'{"userId":13123213123163776887779878}'
```

* When decoding this JWT with the previous logic, precision would be lost for the `userId` value.
* After applying this PR, the `userId` will be decoded correctly as a string, preserving its full value.

### References
* No related posts or forum threads, as this is a code-level issue fix.

### Testing

* To test this fix, reviewers can:

  * Use JWTs with large integers, such as the `userId` value above, and ensure the number is correctly parsed as a string, without losing precision.
  * Review the new unit tests in `safeJsonParseWithBigInt.test.js` to confirm that the functionality works as expected.


### Checklist

* [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
* [ ] All active GitHub checks for tests, formatting, and security are passing
* [ ] The correct base branch is being used, if not the default branch
