### PR TITLE
fix: remove safe-buffer dependency, use built-in Buffer

### DIFF
--- a/lib/data-stream.js
+++ b/lib/data-stream.js
@@ -1,5 +1,4 @@
 /*global module, process*/
-var Buffer = require('safe-buffer').Buffer;
 var Stream = require('stream');
 var util = require('util');
 

--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -1,5 +1,4 @@
 /*global module*/
-var Buffer = require('safe-buffer').Buffer;
 var DataStream = require('./data-stream');
 var jwa = require('jwa');
 var Stream = require('stream');

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -1,5 +1,4 @@
 /*global module*/
-var Buffer = require('safe-buffer').Buffer;
 var DataStream = require('./data-stream');
 var jwa = require('jwa');
 var Stream = require('stream');

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "jwa": "^2.0.1",
-    "safe-buffer": "^5.0.1"
+    "jwa": "^2.0.1"
   },
   "devDependencies": {
     "semver": "^5.1.0",

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -1,5 +1,4 @@
 /*global process*/
-const Buffer = require('safe-buffer').Buffer;
 const fs = require('fs');
 const test = require('tape');
 const jws = require('..');


### PR DESCRIPTION
## Summary
- Removed `safe-buffer` dependency from `package.json`
- Replaced `require('safe-buffer').Buffer` with the built-in `Buffer` global in `lib/data-stream.js`, `lib/sign-stream.js`, `lib/verify-stream.js`, and `test/jws.test.js`
- `Buffer.from()` and `Buffer.alloc()` are available natively in all supported Node.js versions (>=6), making `safe-buffer` unnecessary
- This also fixes ESM bundling issues where `safe-buffer`'s internal `require("buffer")` causes runtime errors

All 81 tests pass.

Closes #112