### PR TITLE
ci: switch to conventionalcommits preset for semantic-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -37,7 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEXT_VERSION=$(npx semantic-release --dry-run --plugins @semantic-release/commit-analyzer | tee /dev/stderr | awk '/The next release version is/{print $NF}')
+          # Run semantic-release with dry-run to detect version
+          NEXT_VERSION=$(npx semantic-release --dry-run --verify-conditions false | tee /dev/stderr | awk '/The next release version is/{print $NF}')
           echo "next=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update package.json
@@ -48,7 +49,7 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: steps.version.outputs.next != ''
-        run: npx conventional-changelog-cli -p angular -i CHANGELOG.md -s
+        run: npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s
 
       - name: Create Pull Request
         if: steps.version.outputs.next != ''

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,8 +3,18 @@
     "master"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/npm",
       {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@semantic-release/exec": "^7.0.3",
+    "conventional-changelog-conventionalcommits": "^9.3.0",
     "husky": "^9.1.7",
     "semantic-release": "^25.0.2",
     "semver": "^5.1.0",


### PR DESCRIPTION
By submitting a PR to this repository, I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- Switch `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` to use the `conventionalcommits` preset, enabling `feat!` notation for breaking changes
- Replace semantic-release dry-run version detection in prepare-release workflow with `semantic-release --dry-run --verify-conditions false` to avoid token requirements while correctly detecting versions
- Update changelog generation in prepare-release workflow to use `conventionalcommits` preset


### Testing

```
npx semantic-release --dry-run --verify-conditions false --branches "ci/conventional-commits"
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
